### PR TITLE
Fix typo in deployment.yaml, replaceImageTag

### DIFF
--- a/employee-management-manifests/deployment.yml
+++ b/employee-management-manifests/deployment.yml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: Employee-Management-System
-        image: gadagojushiva/employee-management-system:14
+        image: gadagojushiva/employee-management-system:replaceImageTag 
         ports:
         - containerPort: 8080


### PR DESCRIPTION
This pull request addresses a minor typo in the deployment.yml file where the term replaceImagTag should be corrected to replaceImageTag. This typo affects the clarity of the configuration and could potentially lead to issues during deployment.